### PR TITLE
bugfix for header error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ rsconnect/
 .Rproj.user
 
 .DS_Store
+
+*.Rproj

--- a/R/clean_header.R
+++ b/R/clean_header.R
@@ -29,7 +29,7 @@ clean_header <- function(df) {
   list_colnames <- purrr::map(1:nrow(header), function(i) {
     header %>%
       dplyr::filter(dplyr::row_number() == i) %>%
-      dplyr::slice(.) %>%
+      #dplyr::slice(.) %>%
       c(., recursive=TRUE) %>%
       unname()
   })


### PR DESCRIPTION
When calling:

 `df <- destatiscleanr::destatiscleanr("https://www-genesis.destatis.de/genesisWS/rest/2020/data/tablefile?username=WRONGUSER&password=WRONGPASS&name=31111-0006&format=csv&language=en")`

an error is presented when processing the header of the downloaded content. By removing `dplyr::slice(.) %>%` from `R/clean_header.R` this error will not take place anymore.

![image](https://github.com/cutterkom/destatiscleanr/assets/43173895/93db34da-bfaa-47d4-9770-eacf68973897)
